### PR TITLE
Add support for git repositories accessible only by ssh keys[Shorter version]

### DIFF
--- a/cooker/cooker-menu-schema.json
+++ b/cooker/cooker-menu-schema.json
@@ -40,7 +40,7 @@
 
                     "url": {
                         "type": "string",
-                        "pattern": "^(https?|ssh|git)://.*$"
+                        "pattern": "^(https?|ssh|git):(//.*$)|(@*.git)"
                     },
 
                     "branch": {

--- a/sample-menus/qemux86-warrior-menu-short-ssh.json
+++ b/sample-menus/qemux86-warrior-menu-short-ssh.json
@@ -4,7 +4,7 @@
 	],
 	"sources" : [
 		{ "url": "git://git.yoctoproject.org/poky", "branch": "warrior", "rev": "warrior-21.0.3" },
-		{ "url": "git@github.com:openembedded/meta-openembedded.git", "branch": "warrior", "rev": "a24acf94d48d635eca668ea34598c6e5c857e3f8" }
+		{ "url": "git@github.com:openembedded/meta-openembedded.git", "branch": "warrior", "rev": "a24acf94d48d635eca668ea34598c6e5c857e3f8", "dir": "meta-openembedded" }
 	],
 
 	"layers" : [

--- a/sample-menus/qemux86-warrior-menu-short-ssh.json
+++ b/sample-menus/qemux86-warrior-menu-short-ssh.json
@@ -1,0 +1,38 @@
+{
+	"notes" : [
+		"Please refer to the README file for instruction on how to build the image"
+	],
+	"sources" : [
+		{ "url": "git://git.yoctoproject.org/poky", "branch": "warrior", "rev": "warrior-21.0.3" },
+		{ "url": "git@github.com:openembedded/meta-openembedded.git", "branch": "warrior", "rev": "a24acf94d48d635eca668ea34598c6e5c857e3f8" }
+	],
+
+	"layers" : [
+		"poky/meta",
+		"poky/meta-poky",
+		"poky/meta-yocto-bsp",
+		"meta-openembedded/meta-oe"
+	],
+
+	"builds" : {
+
+		"qemu-x86": {
+
+			"notes" : [
+				" The default `core-image-base` image for qemu x86 emulation"
+			],
+
+			"target" : "core-image-base",
+
+			"layers" : [
+			],
+
+			"local.conf": [
+				"MACHINE                    = 'qemux86'            ",
+				"INHERIT                   += 'extrausers'              ",
+				"EXTRA_USERS_PARAMS_append = 'usermod -P root  root;' "
+			]
+		}
+	}
+}
+


### PR DESCRIPTION
Hi, 

I propose this modification to add support for git accessible only by SSH. (no web acces) like : git@url:path/to/repo to fix this error : 
```
Failed validating 'pattern' in schema['properties']['sources']['items']['properties']['url']:
    {'pattern': '^(https?|ssh|git)://.*$', 'type': 'string'}
```
Thank you