### PR TITLE
Fix pi3 sample menu

### DIFF
--- a/sample-menus/pi3-sample-menu.json
+++ b/sample-menus/pi3-sample-menu.json
@@ -24,6 +24,8 @@
 				"The default `core-image-base` image is used for bitbake."
 			],
 
+			"target" : "core-image-base",
+
 			"layers" : [
 					"meta-raspberrypi"
 			],
@@ -31,7 +33,7 @@
 			"local.conf": [
 				"MACHINE = 'raspberrypi3' ",
 				"ENABLE_UART = '1' ",
-				"CMDLINE += 'quiet' "
+				"CMDLINE_append += 'quiet' "
 			]
 		}
 	}


### PR DESCRIPTION
1. Add a target
2. Fix cmdline erasure. When using the variable CMDLINE, the original command line is erased. Using CMDLINE_append avoids this issue.
