### PR TITLE
add raspberry pi 2 dunfell menu

### DIFF
--- a/sample-menus/raspberrypi2-dunfell-menu.json
+++ b/sample-menus/raspberrypi2-dunfell-menu.json
@@ -1,0 +1,44 @@
+{
+	"sources" : [
+		{ "url": "git://git.yoctoproject.org/poky", "branch": "dunfell", "rev": "dunfell-23.0.7" },
+		{ "url": "git://git.openembedded.org/meta-openembedded", "branch": "dunfell", "rev": "c1a50683225b0bf10f8d7a18280acefa7469ecc2" },
+		{ "url": "git://git.yoctoproject.org/meta-raspberrypi", "branch": "dunfell", "rev": "77190af02d48adc2b28216775e6318e9eeda571c" }
+	],
+
+	"layers" : [
+		"poky/meta",
+		"poky/meta-poky",
+		"poky/meta-yocto-bsp",
+		"meta-openembedded/meta-oe"
+	],
+
+	"builds" : {
+
+		"pi2-base": {
+
+			"notes": [
+				"Base image for Raspberry Pi 2",
+				"The generated sdcard image is:",
+				"build-pi2-base/tmp/deploy/images/raspberrypi2/core-image-base-raspberrypi2.rpi-sdimg",
+				"To flash the sdcard image, identify your sdcard device with lsblk -p",
+				"Unmount any partition related with your sdcard with umount /dev/mmcblk0X",
+				"Flash the sdcard with: dd if=core-image-base-raspberrypi2.rpi-sdimg of=/dev/mmcblk0 conv=fsync bs=1M",
+				"Boot the pi2 with the sdcard, default user is root with root password"
+			],
+
+			"target" : "core-image-base",
+
+			"layers" : [
+				"meta-raspberrypi"
+			],
+
+			"local.conf": [
+				"MACHINE = 'raspberrypi2'",
+				"ENABLE_UART = '1'",
+				"INHERIT += 'extrausers'",
+				"IMAGE_FSTYPES = 'tar.bz2 ext3 wic.bz2 wic.bmap rpi-sdimg'",
+				"EXTRA_USERS_PARAMS_append = 'usermod -P root root;'"
+			]
+		}
+	}
+}


### PR DESCRIPTION
Hi Christophe & Pat,
Just a simple menu addition for my raspberry pi 2. As dunfell is LTS version, it's even more interesting than any zeus or warrior menus provided in this repo.
Compilation tested under Ubuntu 18.04.
Regards,
Adrien M.