### PR TITLE
coocker/cooker.py: build command should not try to build configuratio…

### DIFF
--- a/cooker/cooker.py
+++ b/cooker/cooker.py
@@ -521,7 +521,8 @@ class CookerCommands:
         debug('Building build-configurations')
 
         for build in self.filter_build_configs(builds):
-            self.build_target(build, sdk)
+            if build.buildable():
+                self.build_target(build, sdk)
 
 
     def build_target(self, build, sdk):

--- a/cooker/cooker.py
+++ b/cooker/cooker.py
@@ -194,6 +194,11 @@ class BuildConfiguration:
 
 
     def target(self):
+        if self.target_ is None:
+            for build in self.ancestors_ + [ self ]:
+                if build.target_ is not None:
+                    return build.target_
+
         return self.target_
 
 


### PR DESCRIPTION
…n template

Since commit 356a75a3584d8d52200ec8737b38d53548c4b20a, the build function
must check if the build configuration is not a template.

Signed-off-by: Romain Naour <romain.naour@smile.fr>