### PR TITLE
cooker: add --keepgoing option for build command

### DIFF
--- a/cooker/cooker.py
+++ b/cooker/cooker.py
@@ -516,17 +516,21 @@ class CookerCommands:
                 if build.ancestors_:
                     info('builds ancestors:', [n.name() for n in build.ancestors_])
 
-    def build(self, builds, sdk):
+    def build(self, builds, sdk, keepgoing):
         debug('Building build-configurations')
 
         for build in self.get_buildable_builds(builds):
-            self.build_target(build, sdk)
+            self.build_target(build, sdk, keepgoing)
 
-    def build_target(self, build, sdk):
+    def build_target(self, build, sdk, keepgoing):
         try:
             info('Building {} ({})'.format(build.name(), build.target()))
+            bb_task = ""
 
-            self.run_bitbake(build, "", build.target())
+            if keepgoing:
+                bb_task = "-k"
+
+            self.run_bitbake(build, bb_task, build.target())
             if sdk:
                 self.run_bitbake(build, "-c populate_sdk", build.target())
 
@@ -613,6 +617,7 @@ class CookerCall:
 
         # `cook` command (`init` + `update` + `generate`)
         cook_parser = subparsers.add_parser('cook', help='prepare the directories and cook the menu')
+        cook_parser.add_argument('-k', '--keepgoing', action='store_true', help='Continue as much as possible after an error')
         cook_parser.add_argument('-s', '--sdk', action='store_true', help='build also the SDK')
         cook_parser.add_argument('menu', help='filename of the JSON menu', type=argparse.FileType('r'), nargs=1)
         cook_parser.add_argument('builds', help='build-configuration to build', nargs='*')
@@ -656,6 +661,7 @@ class CookerCall:
 
         # `build` command
         build_parser = subparsers.add_parser('build', help='build one or more configurations')
+        build_parser.add_argument('-k', '--keepgoing', action='store_true', help='Continue as much as possible after an error')
         build_parser.add_argument('-s', '--sdk', action='store_true', help='build also the SDK')
         build_parser.add_argument('builds', help='build-configuration to build', nargs='*')
         build_parser.set_defaults(func=self.build)
@@ -771,7 +777,7 @@ class CookerCall:
         self.commands.init(self.clargs.menu[0].name)
         self.commands.update()
         self.commands.generate()
-        self.commands.build(self.clargs.builds, self.clargs.sdk)
+        self.commands.build(self.clargs.builds, self.clargs.sdk, self.clargs.keepgoing)
 
     def generate(self):
         if self.menu is None:
@@ -794,7 +800,7 @@ class CookerCall:
         if self.menu is None:
             fatal_error('build needs a menu')
 
-        self.commands.build(self.clargs.builds, self.clargs.sdk)
+        self.commands.build(self.clargs.builds, self.clargs.sdk, self.clargs.keepgoing)
 
     def shell(self):
         if self.menu is None:

--- a/test/basic/build/test
+++ b/test/basic/build/test
@@ -67,3 +67,29 @@ cat > menu.json <<-EOF
 EOF
 cooker init -f menu.json
 cooker build
+
+
+# `cooker build --keepgoing` calls `bitbake -k`
+cat > menu.json <<-EOF
+	{
+	    "sources": [],
+	    "layers": [],
+	    "builds": {
+	        "target-1": {
+	            "target": "core-image-base",
+	            "local.conf": [
+	                "MACHINE = qemu-x86"
+	            ]
+	        }
+	    }
+	}
+EOF
+cooker init -f menu.json
+cat > bitbake <<-EOF
+	#! /bin/sh
+	echo "\$@" >> bitbake.log
+	exit 0
+EOF
+rm -f bitbake.log
+cooker build --keepgoing
+textInFile bitbake.log "k core-image-base" 1


### PR DESCRIPTION
bitbake provide the option '-k' or '--continue' to continue as much as
possible after an error.

This is useful for the first build for a new target or after a layer
update when we can expect having some build issues.

Add a new test that check if "-k" is on the bitbake command line if
--keepgoing is used.

Signed-off-by: Romain Naour <romain.naour@gmail.com>