### PR TITLE
[FIX] `--help` option: program name is `cooker`, not `Cooker`.

### DIFF
--- a/cooker/cooker.py
+++ b/cooker/cooker.py
@@ -606,7 +606,7 @@ class CookerCall:
     os = OsCalls()
 
     def __init__(self):
-        parser = argparse.ArgumentParser(prog='Cooker')
+        parser = argparse.ArgumentParser(prog='cooker')
 
         parser.add_argument('--debug', action='store_true', help='activate debug printing')
         parser.add_argument('--version', action='store_true', help='cooker version')


### PR DESCRIPTION
Previously: 

```
$ cooker --help
usage: Cooker [-h] [--debug] [--version] [-v] [-n] {cook,init,update,generate,show,build,shell,clean} ...
[...]
```

After fix: 

```
$ cooker --help
usage: cooker [-h] [--debug] [--version] [-v] [-n] {cook,init,update,generate,show,build,shell,clean} ...
[...]
```
