### PR TITLE
[FIX] Protect directories variables when outputing the `--dry-run` shell script

### DIFF
--- a/cooker/cooker.py
+++ b/cooker/cooker.py
@@ -78,7 +78,7 @@ class DryRunOsCalls:
         return 0
 
     def file_write(self, file, string):
-        print('\t{}'.format(string))
+        print('\t{}'.format(string.replace('$', '\$')))
         sys.stdout.flush()
 
     def file_close(self, file):

--- a/test/basic/dry-run/output.ref
+++ b/test/basic/dry-run/output.ref
@@ -21,9 +21,9 @@ cat > /builds/build-pi2-base/conf/local.conf <<-EOF
 	# DO NOT EDIT! - This file is automatically created by cooker.
 
 
-	COOKER_LAYER_DIR = "${TOPDIR}/../../layers"
-	DL_DIR = "${TOPDIR}/../../downloads"
-	SSTATE_DIR = "${TOPDIR}/../../sstate-cache"
+	COOKER_LAYER_DIR = "\${TOPDIR}/../../layers"
+	DL_DIR = "\${TOPDIR}/../../downloads"
+	SSTATE_DIR = "\${TOPDIR}/../../sstate-cache"
 	MACHINE = 'raspberrypi2'
 	ENABLE_UART = '1'
 	INHERIT += 'extrausers'
@@ -31,13 +31,13 @@ cat > /builds/build-pi2-base/conf/local.conf <<-EOF
 	DISTRO ?= "poky"
 	PACKAGE_CLASSES ?= "package_rpm"
 	BB_DISKMON_DIRS ??= "\
-		STOPTASKS,${TMPDIR},1G,100K \
-		STOPTASKS,${DL_DIR},1G,100K \
-		STOPTASKS,${SSTATE_DIR},1G,100K \
+		STOPTASKS,\${TMPDIR},1G,100K \
+		STOPTASKS,\${DL_DIR},1G,100K \
+		STOPTASKS,\${SSTATE_DIR},1G,100K \
 		STOPTASKS,/tmp,100M,100K \
-		ABORT,${TMPDIR},100M,1K \
-		ABORT,${DL_DIR},100M,1K \
-		ABORT,${SSTATE_DIR},100M,1K \
+		ABORT,\${TMPDIR},100M,1K \
+		ABORT,\${DL_DIR},100M,1K \
+		ABORT,\${SSTATE_DIR},100M,1K \
 		ABORT,/tmp,10M,1K"
 	CONF_VERSION = "1"
 EOF
@@ -46,14 +46,14 @@ cat > /builds/build-pi2-base/conf/bblayers.conf <<-EOF
 
 
 	POKY_BBLAYERS_CONF_VERSION = "2"
-	BBPATH = "${TOPDIR}"
+	BBPATH = "\${TOPDIR}"
 	BBFILES ?= ""
 	BBLAYERS ?= " \
-		${TOPDIR}/../../layers/meta-openembedded/meta-oe \
-		${TOPDIR}/../../layers/meta-raspberrypi \
-		${TOPDIR}/../../layers/poky/meta \
-		${TOPDIR}/../../layers/poky/meta-poky \
-		${TOPDIR}/../../layers/poky/meta-yocto-bsp \
+		\${TOPDIR}/../../layers/meta-openembedded/meta-oe \
+		\${TOPDIR}/../../layers/meta-raspberrypi \
+		\${TOPDIR}/../../layers/poky/meta \
+		\${TOPDIR}/../../layers/poky/meta-poky \
+		\${TOPDIR}/../../layers/poky/meta-yocto-bsp \
 	"
 
 EOF


### PR DESCRIPTION
The standard output of `cooker --dry-run cook <menu>` is a ready-to-run shell script.

Without this patch the `TOPDIR` variable (and some others) was evaluated (as empty string)
by the shell script and `local.conf` and `bblayers.conf` contains invalid lines.

This patch ensures that the `${TOPDIR}` string (and the others) appears in the `local.conf` and
`bblayers.conf` files and is evaluated later by `bitbake`.
