### PR TITLE
[DEV] Support multiple targets

### DIFF
--- a/cooker/cooker-menu-schema.json
+++ b/cooker/cooker-menu-schema.json
@@ -10,6 +10,14 @@
                 "uniqueItems": true
             }
         },
+        "targets": {
+            "type": "array",
+            "items": {
+                "type": "string",
+                "minLength": 1,
+                "uniqueItems": true
+            }
+        },
         "notes": {
             "type": "array",
             "items": {
@@ -95,8 +103,15 @@
                         },
 
                         "target": {
-                            "type": "string",
-                            "minLength": 1
+                            "anyOf": [
+                                {
+                                    "type": "string",
+                                    "minLength": 1
+                                },
+                                {
+                                    "$ref": "#/definitions/targets"
+                                }
+                            ]
                         },
 
                         "layers": {

--- a/cooker/cooker.py
+++ b/cooker/cooker.py
@@ -493,7 +493,7 @@ class CookerCommands:
             build = BuildConfiguration.ALL[build_name]
 
             if build.targets():
-                build_info = ' (bakes {})'.format(build.targets())
+                build_info = ' (bakes {})'.format(', '.join(build.targets()))
             else:
                 build_info = ''
 

--- a/cooker/cooker.py
+++ b/cooker/cooker.py
@@ -179,7 +179,12 @@ class BuildConfiguration:
         self.config_ = config
         self.layers_ = layers
         self.local_conf_ = local_conf
-        self.target_ = target
+        if type(target) == list:
+            self.targets_ = target
+        elif target:
+            self.targets_ = [target]
+        else:
+            self.targets_ = []
         self.inherit_ = inherit
 
         self.parents_ = []  # first level parents
@@ -187,13 +192,13 @@ class BuildConfiguration:
 
         BuildConfiguration.ALL[name] = self
 
-    def target(self):
+    def targets(self):
         if not self.buildable():
             return None
 
         for build in [self] + self.ancestors_[::-1]:
-            if build.target_:
-                return build.target_
+            if build.targets_:
+                return build.targets_
 
     def name(self):
         return self.name_
@@ -205,7 +210,7 @@ class BuildConfiguration:
         if self.name_.startswith('.'):  # template
             return False
 
-        return any(build.target_ for build in self.ancestors_ + [self])
+        return any(build.targets_ for build in self.ancestors_ + [self])
 
     def layers(self):
         layers = []
@@ -487,8 +492,8 @@ class CookerCommands:
         for build_name in sorted(builds):
             build = BuildConfiguration.ALL[build_name]
 
-            if build.target():
-                build_info = ' (bakes {})'.format(build.target())
+            if build.targets():
+                build_info = ' (bakes {})'.format(build.targets())
             else:
                 build_info = ''
 
@@ -505,7 +510,7 @@ class CookerCommands:
                     info('  - {}'.format(entry))
 
             if build_arg:
-                if build.target():
+                if build.targets():
                     info('  .',
                          os.path.relpath(self.config.layer_dir(CookerCommands.DEFAULT_INIT_BUILD_SCRIPT), os.getcwd()),
                          os.path.relpath(build.dir(), os.getcwd()))
@@ -520,25 +525,26 @@ class CookerCommands:
         debug('Building build-configurations')
 
         for build in self.get_buildable_builds(builds):
-            self.build_target(build, sdk, keepgoing, download)
+            self.build_targets(build, sdk, keepgoing, download)
 
-    def build_target(self, build, sdk, keepgoing, download):
-        try:
-            info('Building {} ({})'.format(build.name(), build.target()))
-            bb_task = ""
+    def build_targets(self, build, sdk, keepgoing, download):
+        for target in build.targets():
+            try:
+                info('Building {} ({})'.format(build.name(), target))
+                bb_task = ""
 
-            if keepgoing:
-                bb_task = "-k"
+                if keepgoing:
+                    bb_task = "-k"
 
-            if download:
-                bb_task += " --runall=fetch"
+                if download:
+                    bb_task += " --runall=fetch"
 
-            self.run_bitbake(build, bb_task, build.target())
-            if sdk:
-                self.run_bitbake(build, "-c populate_sdk", build.target())
+                self.run_bitbake(build, bb_task, target)
+                if sdk:
+                    self.run_bitbake(build, "-c populate_sdk", target)
 
-        except Exception as e:
-            fatal_error('build for', build.name(), 'failed', e)
+            except Exception as e:
+                fatal_error('build for', build.name(), 'failed', e)
 
     def clean(self, recipe, builds):
         debug('cleaning {}'.format(recipe))
@@ -562,7 +568,7 @@ class CookerCommands:
                 if build not in BuildConfiguration.ALL:
                     fatal_error('undefined build:', build)
 
-                if not BuildConfiguration.ALL[build].target():
+                if not BuildConfiguration.ALL[build].targets():
                     fatal_error('build', build, 'is not buildable')
 
                 buildables += [BuildConfiguration.ALL[build]]

--- a/test/basic/generate/multiple-targets.json
+++ b/test/basic/generate/multiple-targets.json
@@ -1,0 +1,27 @@
+{
+    "sources": [],
+    "layers": [
+        "generic/layer1",
+        "generic/layer2"
+    ],
+    "builds": {
+        "one-multiple": {
+            "target": ["bitbake-target"],
+            "layers": [
+                "first/layer1"
+            ]
+        },
+        "two-multiple": {
+            "target": ["bitbake-target", "core-image-base"],
+            "layers": [
+                "first/layer1"
+            ]
+        },
+        "three-multiple": {
+            "target": ["bitbake-target", "core-image-base", "aaa"],
+            "layers": [
+                "first/layer1"
+            ]
+        }
+    }
+}

--- a/test/basic/generate/test
+++ b/test/basic/generate/test
@@ -32,6 +32,15 @@ cooker generate
 textInFile builds/build-first/conf/local.conf 'COOKER_LAYER_DIR = "\${TOPDIR}/../../layers"' 0
 textInFile builds/build-first/conf/local.conf 'COOKER_LAYER_DIR = "\${TOPDIR}/../../layers_dir"' 1
 
+# multiple targets
+cooker init -f $S/multiple-targets.json
+cooker generate
+
+dirsExist . builds 1
+dirsExist builds build-one-multiple 1
+dirsExist builds build-two-multiple 1
+dirsExist builds build-three-multiple 1
+
 # inherited target
 cooker init -f $S/build-template-menu.json
 cooker generate

--- a/test/basic/inheritance/menu.json
+++ b/test/basic/inheritance/menu.json
@@ -36,6 +36,27 @@
                 "MACHINE = three"
             ],
             "target": "target3"
+        },
+        ".virtual-multi": {
+            "inherit": ["base"],
+            "target": ["virtual-multi-target-1", "virtual-multi-target-2"]
+        },
+        "target4" : {
+            "inherit": [".virtual-multi"],
+            "layers": [
+                "meta-target4-1",
+                "meta-target4-2"
+            ],
+            "local.conf": [
+                "MACHINE = four"
+            ]
+        },
+        "target5" : {
+            "inherit": [".virtual-multi"],
+            "local.conf": [
+                "MACHINE = five"
+            ],
+            "target": "target5"
         }
     }
 }

--- a/test/basic/inheritance/show-all.ref
+++ b/test/basic/inheritance/show-all.ref
@@ -5,6 +5,13 @@
 #   - BASE = base
 # build .virtual-base has no target
 # builds ancestors: ['root', 'base']
+# build: .virtual-multi
+#  used layers
+#   - meta-base (/layers/meta-base)
+#  local.conf entries
+#   - BASE = base
+# build .virtual-multi has no target
+# builds ancestors: ['root', 'base']
 # build: base
 #  used layers
 #   - meta-base (/layers/meta-base)
@@ -16,7 +23,7 @@
 #  used layers
 #  local.conf entries
 # build root has no target
-# build: target1 (bakes virtual-base-target)
+# build: target1 (bakes ['virtual-base-target'])
 #  used layers
 #   - meta-base (/layers/meta-base)
 #   - meta-target1-1 (/layers/meta-target1-1)
@@ -34,7 +41,7 @@
 #   - MACHINE = two
 # build target2 has no target
 # builds ancestors: ['root', 'base']
-# build: target3 (bakes target3)
+# build: target3 (bakes ['target3'])
 #  used layers
 #   - meta-base (/layers/meta-base)
 #  local.conf entries
@@ -42,3 +49,21 @@
 #   - MACHINE = three
 #   . layers/poky/oe-init-build-env builds/build-target3
 # builds ancestors: ['root', 'base', '.virtual-base']
+# build: target4 (bakes ['virtual-multi-target-1', 'virtual-multi-target-2'])
+#  used layers
+#   - meta-base (/layers/meta-base)
+#   - meta-target4-1 (/layers/meta-target4-1)
+#   - meta-target4-2 (/layers/meta-target4-2)
+#  local.conf entries
+#   - BASE = base
+#   - MACHINE = four
+#   . layers/poky/oe-init-build-env builds/build-target4
+# builds ancestors: ['root', 'base', '.virtual-multi']
+# build: target5 (bakes ['target5'])
+#  used layers
+#   - meta-base (/layers/meta-base)
+#  local.conf entries
+#   - BASE = base
+#   - MACHINE = five
+#   . layers/poky/oe-init-build-env builds/build-target5
+# builds ancestors: ['root', 'base', '.virtual-multi']

--- a/test/basic/inheritance/show-all.ref
+++ b/test/basic/inheritance/show-all.ref
@@ -23,7 +23,7 @@
 #  used layers
 #  local.conf entries
 # build root has no target
-# build: target1 (bakes ['virtual-base-target'])
+# build: target1 (bakes virtual-base-target)
 #  used layers
 #   - meta-base (/layers/meta-base)
 #   - meta-target1-1 (/layers/meta-target1-1)
@@ -41,7 +41,7 @@
 #   - MACHINE = two
 # build target2 has no target
 # builds ancestors: ['root', 'base']
-# build: target3 (bakes ['target3'])
+# build: target3 (bakes target3)
 #  used layers
 #   - meta-base (/layers/meta-base)
 #  local.conf entries
@@ -49,7 +49,7 @@
 #   - MACHINE = three
 #   . layers/poky/oe-init-build-env builds/build-target3
 # builds ancestors: ['root', 'base', '.virtual-base']
-# build: target4 (bakes ['virtual-multi-target-1', 'virtual-multi-target-2'])
+# build: target4 (bakes virtual-multi-target-1, virtual-multi-target-2)
 #  used layers
 #   - meta-base (/layers/meta-base)
 #   - meta-target4-1 (/layers/meta-target4-1)
@@ -59,7 +59,7 @@
 #   - MACHINE = four
 #   . layers/poky/oe-init-build-env builds/build-target4
 # builds ancestors: ['root', 'base', '.virtual-multi']
-# build: target5 (bakes ['target5'])
+# build: target5 (bakes target5)
 #  used layers
 #   - meta-base (/layers/meta-base)
 #  local.conf entries

--- a/test/basic/show/build-output.ref
+++ b/test/basic/show/build-output.ref
@@ -1,14 +1,14 @@
-# build: delta (bakes ['delta-bitbake-1', 'delta-bitbake-2'])
+# build: delta (bakes delta-bitbake-1, delta-bitbake-2)
 #   . layers/poky/oe-init-build-env builds/build-delta
 # build: first
 # build first has no target
-# build: fourth (bakes ['fourth-bitbake'])
+# build: fourth (bakes fourth-bitbake)
 #   . layers/poky/oe-init-build-env builds/build-fourth
-# build: gamma (bakes ['gamma-bitbake-1', 'gamma-bitbake-2'])
+# build: gamma (bakes gamma-bitbake-1, gamma-bitbake-2)
 #   . layers/poky/oe-init-build-env builds/build-gamma
 # build: root
 # build root has no target
 # build: second
 # build second has no target
-# build: third (bakes ['third-bitbake'])
+# build: third (bakes third-bitbake)
 #   . layers/poky/oe-init-build-env builds/build-third

--- a/test/basic/show/build-output.ref
+++ b/test/basic/show/build-output.ref
@@ -1,10 +1,14 @@
+# build: delta (bakes ['delta-bitbake-1', 'delta-bitbake-2'])
+#   . layers/poky/oe-init-build-env builds/build-delta
 # build: first
 # build first has no target
-# build: fourth (bakes fourth-bitbake)
+# build: fourth (bakes ['fourth-bitbake'])
 #   . layers/poky/oe-init-build-env builds/build-fourth
+# build: gamma (bakes ['gamma-bitbake-1', 'gamma-bitbake-2'])
+#   . layers/poky/oe-init-build-env builds/build-gamma
 # build: root
 # build root has no target
 # build: second
 # build second has no target
-# build: third (bakes third-bitbake)
+# build: third (bakes ['third-bitbake'])
 #   . layers/poky/oe-init-build-env builds/build-third

--- a/test/basic/show/conf-output.ref
+++ b/test/basic/show/conf-output.ref
@@ -1,14 +1,26 @@
+# build: delta (bakes ['delta-bitbake-1', 'delta-bitbake-2'])
+#  local.conf entries
+#   - root=root
+#   - second=second
+#   - gamma=gamma
+#   - first=first
+#   - delta=delta
 # build: first
 #  local.conf entries
 #   - root=root
 #   - first=first
-# build: fourth (bakes fourth-bitbake)
+# build: fourth (bakes ['fourth-bitbake'])
 #  local.conf entries
 #   - root=root
 #   - second=second
 #   - third=third
 #   - first=first
 #   - fourth=fourth
+# build: gamma (bakes ['gamma-bitbake-1', 'gamma-bitbake-2'])
+#  local.conf entries
+#   - root=root
+#   - second=second
+#   - gamma=gamma
 # build: root
 #  local.conf entries
 #   - root=root
@@ -16,7 +28,7 @@
 #  local.conf entries
 #   - root=root
 #   - second=second
-# build: third (bakes third-bitbake)
+# build: third (bakes ['third-bitbake'])
 #  local.conf entries
 #   - root=root
 #   - second=second

--- a/test/basic/show/conf-output.ref
+++ b/test/basic/show/conf-output.ref
@@ -1,4 +1,4 @@
-# build: delta (bakes ['delta-bitbake-1', 'delta-bitbake-2'])
+# build: delta (bakes delta-bitbake-1, delta-bitbake-2)
 #  local.conf entries
 #   - root=root
 #   - second=second
@@ -9,14 +9,14 @@
 #  local.conf entries
 #   - root=root
 #   - first=first
-# build: fourth (bakes ['fourth-bitbake'])
+# build: fourth (bakes fourth-bitbake)
 #  local.conf entries
 #   - root=root
 #   - second=second
 #   - third=third
 #   - first=first
 #   - fourth=fourth
-# build: gamma (bakes ['gamma-bitbake-1', 'gamma-bitbake-2'])
+# build: gamma (bakes gamma-bitbake-1, gamma-bitbake-2)
 #  local.conf entries
 #   - root=root
 #   - second=second
@@ -28,7 +28,7 @@
 #  local.conf entries
 #   - root=root
 #   - second=second
-# build: third (bakes ['third-bitbake'])
+# build: third (bakes third-bitbake)
 #  local.conf entries
 #   - root=root
 #   - second=second

--- a/test/basic/show/fourth-all-output.ref
+++ b/test/basic/show/fourth-all-output.ref
@@ -1,4 +1,4 @@
-# build: fourth (bakes fourth-bitbake)
+# build: fourth (bakes ['fourth-bitbake'])
 #  used layers
 #   - root/1 (/layers/root/1)
 #   - root/2 (/layers/root/2)

--- a/test/basic/show/fourth-all-output.ref
+++ b/test/basic/show/fourth-all-output.ref
@@ -1,4 +1,4 @@
-# build: fourth (bakes ['fourth-bitbake'])
+# build: fourth (bakes fourth-bitbake)
 #  used layers
 #   - root/1 (/layers/root/1)
 #   - root/2 (/layers/root/2)

--- a/test/basic/show/layer-output.ref
+++ b/test/basic/show/layer-output.ref
@@ -1,10 +1,22 @@
+# build: delta (bakes ['delta-bitbake-1', 'delta-bitbake-2'])
+#  used layers
+#   - root/1 (/layers/root/1)
+#   - root/2 (/layers/root/2)
+#   - 2/1 (/layers/2/1)
+#   - 2/2 (/layers/2/2)
+#   - G/1 (/layers/G/1)
+#   - G/2 (/layers/G/2)
+#   - 1/1 (/layers/1/1)
+#   - 1/2 (/layers/1/2)
+#   - D/1 (/layers/D/1)
+#   - D/2 (/layers/D/2)
 # build: first
 #  used layers
 #   - root/1 (/layers/root/1)
 #   - root/2 (/layers/root/2)
 #   - 1/1 (/layers/1/1)
 #   - 1/2 (/layers/1/2)
-# build: fourth (bakes fourth-bitbake)
+# build: fourth (bakes ['fourth-bitbake'])
 #  used layers
 #   - root/1 (/layers/root/1)
 #   - root/2 (/layers/root/2)
@@ -16,6 +28,14 @@
 #   - 1/2 (/layers/1/2)
 #   - 4/1 (/layers/4/1)
 #   - 4/2 (/layers/4/2)
+# build: gamma (bakes ['gamma-bitbake-1', 'gamma-bitbake-2'])
+#  used layers
+#   - root/1 (/layers/root/1)
+#   - root/2 (/layers/root/2)
+#   - 2/1 (/layers/2/1)
+#   - 2/2 (/layers/2/2)
+#   - G/1 (/layers/G/1)
+#   - G/2 (/layers/G/2)
 # build: root
 #  used layers
 #   - root/1 (/layers/root/1)
@@ -26,7 +46,7 @@
 #   - root/2 (/layers/root/2)
 #   - 2/1 (/layers/2/1)
 #   - 2/2 (/layers/2/2)
-# build: third (bakes third-bitbake)
+# build: third (bakes ['third-bitbake'])
 #  used layers
 #   - root/1 (/layers/root/1)
 #   - root/2 (/layers/root/2)

--- a/test/basic/show/layer-output.ref
+++ b/test/basic/show/layer-output.ref
@@ -1,4 +1,4 @@
-# build: delta (bakes ['delta-bitbake-1', 'delta-bitbake-2'])
+# build: delta (bakes delta-bitbake-1, delta-bitbake-2)
 #  used layers
 #   - root/1 (/layers/root/1)
 #   - root/2 (/layers/root/2)
@@ -16,7 +16,7 @@
 #   - root/2 (/layers/root/2)
 #   - 1/1 (/layers/1/1)
 #   - 1/2 (/layers/1/2)
-# build: fourth (bakes ['fourth-bitbake'])
+# build: fourth (bakes fourth-bitbake)
 #  used layers
 #   - root/1 (/layers/root/1)
 #   - root/2 (/layers/root/2)
@@ -28,7 +28,7 @@
 #   - 1/2 (/layers/1/2)
 #   - 4/1 (/layers/4/1)
 #   - 4/2 (/layers/4/2)
-# build: gamma (bakes ['gamma-bitbake-1', 'gamma-bitbake-2'])
+# build: gamma (bakes gamma-bitbake-1, gamma-bitbake-2)
 #  used layers
 #   - root/1 (/layers/root/1)
 #   - root/2 (/layers/root/2)
@@ -46,7 +46,7 @@
 #   - root/2 (/layers/root/2)
 #   - 2/1 (/layers/2/1)
 #   - 2/2 (/layers/2/2)
-# build: third (bakes ['third-bitbake'])
+# build: third (bakes third-bitbake)
 #  used layers
 #   - root/1 (/layers/root/1)
 #   - root/2 (/layers/root/2)

--- a/test/basic/show/menu.json
+++ b/test/basic/show/menu.json
@@ -22,6 +22,18 @@
             "layers": [ "4/1", "4/2"],
             "inherit": ["third", "first"],
             "target": "fourth-bitbake"
+        },
+        "gamma": {
+            "local.conf": [ "gamma=gamma" ],
+            "layers": [ "G/1", "G/2"],
+            "inherit": ["second"],
+            "target": ["gamma-bitbake-1", "gamma-bitbake-2"]
+        },
+        "delta": {
+            "local.conf": [ "delta=delta" ],
+            "layers": [ "D/1", "D/2"],
+            "inherit": ["gamma", "first"],
+            "target": ["delta-bitbake-1", "delta-bitbake-2"]
         }
     }
 }

--- a/test/basic/show/tree-output.ref
+++ b/test/basic/show/tree-output.ref
@@ -1,9 +1,13 @@
+# build: delta (bakes ['delta-bitbake-1', 'delta-bitbake-2'])
+# builds ancestors: ['root', 'second', 'gamma', 'first']
 # build: first
 # builds ancestors: ['root']
-# build: fourth (bakes fourth-bitbake)
+# build: fourth (bakes ['fourth-bitbake'])
 # builds ancestors: ['root', 'second', 'third', 'first']
+# build: gamma (bakes ['gamma-bitbake-1', 'gamma-bitbake-2'])
+# builds ancestors: ['root', 'second']
 # build: root
 # build: second
 # builds ancestors: ['root']
-# build: third (bakes third-bitbake)
+# build: third (bakes ['third-bitbake'])
 # builds ancestors: ['root', 'second']

--- a/test/basic/show/tree-output.ref
+++ b/test/basic/show/tree-output.ref
@@ -1,13 +1,13 @@
-# build: delta (bakes ['delta-bitbake-1', 'delta-bitbake-2'])
+# build: delta (bakes delta-bitbake-1, delta-bitbake-2)
 # builds ancestors: ['root', 'second', 'gamma', 'first']
 # build: first
 # builds ancestors: ['root']
-# build: fourth (bakes ['fourth-bitbake'])
+# build: fourth (bakes fourth-bitbake)
 # builds ancestors: ['root', 'second', 'third', 'first']
-# build: gamma (bakes ['gamma-bitbake-1', 'gamma-bitbake-2'])
+# build: gamma (bakes gamma-bitbake-1, gamma-bitbake-2)
 # builds ancestors: ['root', 'second']
 # build: root
 # build: second
 # builds ancestors: ['root']
-# build: third (bakes ['third-bitbake'])
+# build: third (bakes third-bitbake)
 # builds ancestors: ['root', 'second']


### PR DESCRIPTION
Enable the build of several targets in the same build directory. The field
'target' in the menu can be a single string or an array of string. If given an
array, all entries will be built (the build order is undefined).

This does not affect the previous 'target' behaviour.