### PR TITLE
[DEV] Read `CONF_VERSION` from `local.conf.sample` file.

### DIFF
--- a/test/basic/clean/test
+++ b/test/basic/clean/test
@@ -37,6 +37,7 @@ cooker init -f menu.json
 
 # `cooker clean recipe` fails without Poky `oe-init-build-env` script.
 rm -f layers/poky/oe-init-build-env
+rm -f layers/poky/meta-poky
 
 expect_fail cooker clean recipe
 
@@ -49,6 +50,12 @@ cat > bitbake <<-EOF
 EOF
 chmod +x bitbake
 PATH=.:$PATH
+
+# Add `local.conf.sample` file
+mkdir -p layers/poky/meta-poky/conf
+cat > layers/poky/meta-poky/conf/local.conf.sample <<- EOF
+  CONF_VERSION = "1"
+EOF
 
 # `cooker clean recipe` succeeds when bitbake succeeds.
 export bitbake_result=0
@@ -79,7 +86,7 @@ cooker generate
 
 cooker clean recipe
 
-# `cooker clean recipe buid-config` fails when build-config doesn't exist.
+# `cooker clean recipe build-config` fails when build-config doesn't exist.
 cat > menu.json <<-EOF
 	{
 	    "sources": [],

--- a/test/basic/dry-run/output.ref
+++ b/test/basic/dry-run/output.ref
@@ -39,7 +39,7 @@ cat > /builds/build-pi2-base/conf/local.conf <<-EOF
 		ABORT,\${DL_DIR},100M,1K \
 		ABORT,\${SSTATE_DIR},100M,1K \
 		ABORT,/tmp,10M,1K"
-	CONF_VERSION = "1"
+	CONF_VERSION ?= "1"
 EOF
 cat > /builds/build-pi2-base/conf/bblayers.conf <<-EOF
 	# DO NOT EDIT! - This file is automatically created by cooker.

--- a/test/basic/dry-run/test
+++ b/test/basic/dry-run/test
@@ -4,7 +4,6 @@ expect_fail cooker --dry-run 2> error.txt
 linesInFile error.txt 2
 rm -f error.txt
 
-
 # Mock `bitbake`
 cat > bitbake <<-EOF
         #! /bin/sh
@@ -13,7 +12,6 @@ EOF
 chmod +x bitbake
 
 # Mock `git`
-
 cat > git <<-EOF
 	#! /bin/sh
 	exit 0

--- a/test/basic/generate/test
+++ b/test/basic/generate/test
@@ -1,9 +1,9 @@
-# fail is no init done
-! cooker generate
+# fail if no init done
+expect_fail cooker generate
 
 
 # empty menu, nothing is generated
-cooker init $S/empty-menu.json
+cooker init -f $S/empty-menu.json
 cooker generate
 
 filesExist . builds 0
@@ -22,13 +22,25 @@ dirsExist builds build-first 1
 # bblayers as expected
 diff builds/build-first/conf/bblayers.conf $S/one-target-first-bblayers.conf
 
+# local.conf as expected
 textInFile builds/build-first/conf/local.conf 'COOKER_LAYER_DIR = "\${TOPDIR}/../../layers"' 1
 textInFile builds/build-first/conf/local.conf 'DL_DIR = "\${TOPDIR}/../../downloads"' 1
 textInFile builds/build-first/conf/local.conf 'SSTATE_DIR = "\${TOPDIR}/../../sstate-cache"' 1
 
+# Default value for CONF_VERSION is 1
+textInFile builds/build-first/conf/local.conf 'CONF_VERSION \?= "1"' 1
+# regenerate with CONF_VERSION = 2
+mkdir -p layers/poky/meta-poky/conf
+cat > layers/poky/meta-poky/conf/local.conf.sample <<- EOF
+  CONF_VERSION = "2"
+EOF
+cooker generate
+textInFile builds/build-first/conf/local.conf 'CONF_VERSION \?= "2"' 1
+
 # regenerate after layers-dir-change
 cooker init -f -l layers_dir $S/menu.json
 cooker generate
+
 textInFile builds/build-first/conf/local.conf 'COOKER_LAYER_DIR = "\${TOPDIR}/../../layers"' 0
 textInFile builds/build-first/conf/local.conf 'COOKER_LAYER_DIR = "\${TOPDIR}/../../layers_dir"' 1
 


### PR DESCRIPTION
The path to this file is in `templateconf.cfg`, relative to `poky`
directory (or `openembedded-core` for Arago-based systems).

If the file is missing (for example when running with `--dry-run`)
we use the `DEFAULT_CONF_VERSION` from the Distro config.