### PR TITLE
[DEV] Default to `bash` when running `cooker shell`.

### DIFF
--- a/cooker/cooker.py
+++ b/cooker/cooker.py
@@ -636,7 +636,7 @@ class CookerCommands:
     def shell(self, build_names: List[str]):
         build_dir = self.get_buildable_builds(build_names)[0].dir()
         init_script = self.config.layer_dir(self.distro.BASE_DIRECTORY + "/" + self.distro.BUILD_SCRIPT)
-        shell = os.environ.get('SHELL', '/bin/sh')
+        shell = os.environ.get('SHELL', '/bin/bash')
 
         debug('running interactive, poky-initialized shell {} {} {}', build_dir, init_script, shell)
 


### PR DESCRIPTION
When the `SHELL` environment variable is not defined, we have
to default to `/bin/bash` (like when we launch `bitbake`) instead
of `/bin/sh` which is often a link to `/bin/dash`.

Closes: #99