### PR TITLE
urls: fix validation of ambiguous URLs for schema

### DIFF
--- a/cooker/cooker-menu-schema.json
+++ b/cooker/cooker-menu-schema.json
@@ -52,7 +52,7 @@
                     },
 
                     "url": {
-                        "oneOf": [
+                        "anyOf": [
                             {
                                 "type": "string",
                                 "pattern": "^(https?|ssh|git)://.*$"

--- a/test/basic/source-types/git-sources.json
+++ b/test/basic/source-types/git-sources.json
@@ -5,7 +5,8 @@
         { "method": "git", "url": "http://github.com/openembedded/meta-3.git" },
         { "method": "git", "url": "git://github.com/openembedded/meta-4.git" },
         { "method": "git", "url": "git://github.com/openembedded/meta-5.git", "dir": "meta-5"},
-        { "method": "git", "url": "git@github.com:openembedded/meta-6.git", "dir":  "meta-6"}
+        { "method": "git", "url": "git@github.com:openembedded/meta-6.git", "dir":  "meta-6"},
+        { "method": "git", "url": "ssh://git@gitlab.fdimatelec.fr:1086/mirrors/openembedded/meta-openembedded.git", "dir": "issue-113" }
     ],
 
     "builds" : {

--- a/test/basic/source-types/test
+++ b/test/basic/source-types/test
@@ -9,5 +9,6 @@ textInFile $T/output $T/layers/openembedded/meta-3.git 1
 textInFile $T/output $T/layers/openembedded/meta-4.git 1
 textInFile $T/output $T/layers/meta-5 1
 textInFile $T/output $T/layers/meta-6 1
+textInFile $T/output $T/layers/issue-113 1
 
 exit 0


### PR DESCRIPTION
There are URL which are matching several patterns, this actually OK,
so the schema has to be `anyOf` and not `oneOf` the possible patterns.

fixes #113