### PR TITLE
Add `-s/--sstate-dir` option to `init` command

### DIFF
--- a/cooker/cooker.py
+++ b/cooker/cooker.py
@@ -498,7 +498,7 @@ class CookerCommands:
         CookerCall.os.create_directory(conf_path)
         dl_dir = '${TOPDIR}/' + os.path.relpath(self.config.dl_dir(), build.dir())
 
-        sstate_dir = '${TOPDIR}/' + os.path.relpath( self.config.sstate_dir(), build.dir())
+        sstate_dir = '${TOPDIR}/' + os.path.relpath(self.config.sstate_dir(), build.dir())
         layer_dir = os.path.join('${TOPDIR}', os.path.relpath(self.config.layer_dir(), build.dir()))
 
         file = CookerCall.os.file_open(os.path.join(conf_path, 'local.conf'))

--- a/cooker/cooker.py
+++ b/cooker/cooker.py
@@ -498,8 +498,7 @@ class CookerCommands:
         CookerCall.os.create_directory(conf_path)
         dl_dir = '${TOPDIR}/' + os.path.relpath(self.config.dl_dir(), build.dir())
 
-        sstate_dir = self.config.sstate_dir()
-        sstate_dir = '${TOPDIR}/' + os.path.relpath(sstate_dir, build.dir())
+        sstate_dir = '${TOPDIR}/' + os.path.relpath( self.config.sstate_dir(), build.dir())
         layer_dir = os.path.join('${TOPDIR}', os.path.relpath(self.config.layer_dir(), build.dir()))
 
         file = CookerCall.os.file_open(os.path.join(conf_path, 'local.conf'))

--- a/test/basic/init/test
+++ b/test/basic/init/test
@@ -37,11 +37,12 @@ cooker init $S/menu.json
 fileExists .cookerconfig
 
 # The `.cookerconfig` file is correct.
-linesInFile .cookerconfig 5
+linesInFile .cookerconfig 6
 textInFile .cookerconfig '/menu.json",' 1
 textInFile .cookerconfig '"layer-dir": "layers",' 1
 textInFile .cookerconfig '"build-dir": "builds",' 1
 textInFile .cookerconfig '"dl-dir": "downloads"' 1
+textInFile .cookerconfig '"sstate-dir": "sstate-cache"' 1
 
 # `cooker init` fails if `.cookerconfig` file already exist.
 expect_fail cooker init $S/menu.json
@@ -59,9 +60,9 @@ expect_fail cooker init -f $S/unknown-menu.json
 textInFile .cookerconfig '/menu-copy.json",' 1
 
 # With `-l` option `cooker init` overwrite the `layer-dir` parameter in `.cookerconfig`
-cooker init -fl layers_dir $S/menu.json
-linesInFile .cookerconfig 5
+cooker init -fl layers_dir -s sstate_dir $S/menu.json
+linesInFile .cookerconfig 6
 textInFile .cookerconfig '"layer-dir": "layers_dir",' 1
 textInFile .cookerconfig '"build-dir": "builds",' 1
 textInFile .cookerconfig '"dl-dir": "downloads"' 1
-
+textInFile .cookerconfig '"sstate-dir": "sstate_dir"' 1


### PR DESCRIPTION
This PR adds a new option to the `init` command just like `-d/--dl-dir`