### PR TITLE
[DEV] menu path can be absolute or relative

### DIFF
--- a/cooker/cooker.py
+++ b/cooker/cooker.py
@@ -140,6 +140,7 @@ class Config:
 
                 if found:
                     self.check_and_migrate_config()
+                    self.path = "/".join(path)
                     return
 
                 break
@@ -147,6 +148,7 @@ class Config:
             path.pop()  # cd ..
 
         self.cfg = self.DEFAULT_CONFIG.copy()
+        self.path = ""
 
         debug('No config-file found. Will be using', self.filename)
 
@@ -174,7 +176,10 @@ class Config:
         return os.path.dirname(self.filename)
 
     def set_menu(self, menu_file):
-        self.cfg['menu'] = os.path.realpath(menu_file)
+        if menu_file.startswith('/'):
+            self.cfg['menu'] = os.path.realpath(menu_file)
+        else:
+            self.cfg['menu'] = os.path.relpath(menu_file, self.path)
 
     def set_layer_dir(self, path):
         # paths in the config-file are relative to the project-dir
@@ -202,7 +207,11 @@ class Config:
         return os.path.join(self.project_root(), self.cfg['sstate-dir'], name)
 
     def menu(self):
-        return self.cfg['menu']
+        menu_path = self.cfg['menu']
+        if menu_path.startswith('/'):
+            return menu_path
+        else:
+            return self.path + "/" + menu_path
 
     def save(self):
         debug('Saving configuration file')

--- a/test/basic/init/test
+++ b/test/basic/init/test
@@ -38,12 +38,21 @@ fileExists .cookerconfig
 
 # The `.cookerconfig` file is correct.
 linesInFile .cookerconfig 7
-textInFile .cookerconfig '/menu.json",' 1
+textInFile .cookerconfig $S'/menu.json",' 1
 textInFile .cookerconfig '"layer-dir": "layers",' 1
 textInFile .cookerconfig '"build-dir": "builds",' 1
 textInFile .cookerconfig '"dl-dir": "downloads"' 1
 textInFile .cookerconfig '"sstate-dir": "sstate-cache"' 1
 textInFile .cookerconfig '"cooker-config-version": 1' 1
+rm .cookerconfig
+
+# Initializing with a relative path succeeds
+rel_path="$(realpath --relative-to=. $S/menu.json)"
+cooker init $rel_path
+fileExists .cookerconfig
+
+# The menu path in the `.cookerconfig` file is correct.
+textInFile .cookerconfig $rel_path'",' 1
 
 # `cooker init` fails if `.cookerconfig` file already exist.
 expect_fail cooker init $S/menu.json


### PR DESCRIPTION
When the menu path given in the command init (or cook) started with '/', its absolute path is stored (after symlinks resolution). If not, its path relative to the .cookerconfig is stored (after symlinks resolution).

The aim is to enable to initialize and download the sources in a host machine and build in a container which may have a different location.