### PR TITLE
[FIX] usermod extrauser command

### DIFF
--- a/sample-menus/beaglebone-zeus-menu.json
+++ b/sample-menus/beaglebone-zeus-menu.json
@@ -21,10 +21,7 @@
 		"beaglebone-console": {
 
 			"notes": [
-				" The default `core-image-base` image with some minor   ",
-				" tweaks:                                               ",
-				"  - the root password is 'ROOT' (change it below),     ",
-				"  - a normal 'pi' user (password 'PI') is present.     ",
+				" The default `core-image-base` image.                  ",
 				"                                                       ",
 				" The image to write to your SD-card is:                ",
 				" builds/build-beaglebone-console/tmp/deploy/images/beaglebone-yocto/core-image-base-beaglebone-yocto.wic"
@@ -37,10 +34,7 @@
 
 			"local.conf": [
 				"MACHINE                    = 'beaglebone-yocto'        ",
-				"ENABLE_UART                = '1'                       ",
-				"INHERIT                   += 'extrausers'              ",
-				"EXTRA_USERS_PARAMS_append  = 'usermod -P ROOT root;'   ",
-				"EXTRA_USERS_PARAMS_append  = 'useradd -P BB   bb;'     "
+				"ENABLE_UART                = '1'                       "
 			]
 		}
 	}

--- a/sample-menus/lee2-menu.json
+++ b/sample-menus/lee2-menu.json
@@ -17,9 +17,6 @@
 	],
 
 	"local.conf" : [
-		"INHERIT += 'extrausers'     ",
-		"EXTRA_USERS_PARAMS += 'useradd  -P today  lee2;'  ",
-		"EXTRA_USERS_PARAMS += 'usermod  -P linux  root;'  "
 	],
 
 	"builds" : {

--- a/sample-menus/meetup-paris-embedded-2022-05-18.json
+++ b/sample-menus/meetup-paris-embedded-2022-05-18.json
@@ -18,8 +18,10 @@
 
 	"local.conf" : [
 		"INHERIT += 'extrausers'     ",
-		"EXTRA_USERS_PARAMS += 'useradd  -p c4xYEV.En.4Gg meetup;'  ",
-		"EXTRA_USERS_PARAMS += 'usermod  -p VwL97VCAx1Qhs root;'  ",
+		"# `meetup` password: `meetup` ",
+		"EXTRA_USERS_PARAMS_append  = \"useradd -p \\$5\\$nw3PPmlnKEDXXvQD\\$NzNLKleE4JpcCC9wfEKa6uEyvoAk2wZ8AHnEJISMyF/  meetup;\"   ",
+		"# `root` password: `linux` ",
+		"EXTRA_USERS_PARAMS_append  = \"usermod -p \\$5\\$oWODdN2qVYVBB5Nl\\$NrH9rY/8gxTkbdEbNzBK9Iu5KLlSppkOhooF8sP2mo/  root;\"     ",
 		"BB_NUMBER_THREADS = '4'                             ",
 		"PARALLEL_MAKE = '-j 2'                              "
 	],

--- a/sample-menus/multiple-inheritances-test.json
+++ b/sample-menus/multiple-inheritances-test.json
@@ -23,10 +23,7 @@
 
 			"local.conf": [
 				"ENABLE_UART               = '1'                          ",
-				"EXTRA_IMAGE_FEATURES     += 'read-only-rootfs'           ",
-				"INHERIT                  += 'extrausers'                 ",
-				"EXTRA_USERS_PARAMS_append = 'useradd -P rpi  rpi;'       ",
-				"EXTRA_USERS_PARAMS_append = 'usermod -P root root;'      "
+				"EXTRA_IMAGE_FEATURES     += 'read-only-rootfs'           ".
 			]
 		},
 

--- a/sample-menus/qemux86-warrior-menu-short-ssh.json
+++ b/sample-menus/qemux86-warrior-menu-short-ssh.json
@@ -28,9 +28,7 @@
 			],
 
 			"local.conf": [
-				"MACHINE                    = 'qemux86'            ",
-				"INHERIT                   += 'extrausers'              ",
-				"EXTRA_USERS_PARAMS_append = 'usermod -P root  root;' "
+				"MACHINE                    = 'qemux86'            "
 			]
 		}
 	}

--- a/sample-menus/qemux86-warrior-menu.json
+++ b/sample-menus/qemux86-warrior-menu.json
@@ -28,9 +28,7 @@
 			],
 
 			"local.conf": [
-				"MACHINE                    = 'qemux86'            ",
-				"INHERIT                   += 'extrausers'              ",
-				"EXTRA_USERS_PARAMS_append = 'usermod -P root  root;' "
+				"MACHINE                    = 'qemux86'            "
 			]
 		}
 	}

--- a/sample-menus/raspberrypi-cm3-warrior-menu.json
+++ b/sample-menus/raspberrypi-cm3-warrior-menu.json
@@ -60,12 +60,7 @@
 				"MACHINE          = 'raspberrypi-cm3'  ",
 
 				"ENABLE_UART      = '1'                ",
-				"RPI_USE_U_BOOT   = '1'                ",
-
-				"INHERIT += 'extrausers'   ",
-				"EXTRA_USERS_PARAMS_append = 'usermod -P root  root;' ",
-				"EXTRA_USERS_PARAMS_append = 'useradd -P pi    pi;'  "
-
+				"RPI_USE_U_BOOT   = '1'                "
 			]
 		}
 	}

--- a/sample-menus/raspberrypi2-dunfell-menu.json
+++ b/sample-menus/raspberrypi2-dunfell-menu.json
@@ -34,10 +34,7 @@
 
 			"local.conf": [
 				"MACHINE = 'raspberrypi2'",
-				"ENABLE_UART = '1'",
-				"INHERIT += 'extrausers'",
-				"IMAGE_FSTYPES = 'tar.bz2 ext3 wic.bz2 wic.bmap rpi-sdimg'",
-				"EXTRA_USERS_PARAMS_append = 'usermod -P root root;'"
+				"ENABLE_UART = '1'"
 			]
 		}
 	}

--- a/sample-menus/raspberrypi2-zeus-menu.json
+++ b/sample-menus/raspberrypi2-zeus-menu.json
@@ -34,9 +34,7 @@
 
 			"local.conf": [
 				"MACHINE = 'raspberrypi2'",
-				"ENABLE_UART = '1'",
-				"INHERIT += 'extrausers'",
-				"EXTRA_USERS_PARAMS_append = 'usermod -P root root;'"
+				"ENABLE_UART = '1'"
 			]
 		}
 	}

--- a/sample-menus/raspberrypi4-warrior-menu.json
+++ b/sample-menus/raspberrypi4-warrior-menu.json
@@ -42,9 +42,6 @@
 			"local.conf": [
 				"MACHINE                    = 'raspberrypi4'            ",
 				"ENABLE_UART                = '1'                       ",
-				"INHERIT                   += 'extrausers'              ",
-				"EXTRA_USERS_PARAMS_append  = 'usermod -P ROOT  root;'  ",
-				"EXTRA_USERS_PARAMS_append  = 'useradd -P PI    pi;'    ",
 				"EXTRA_IMAGE_FEATURES      += 'read-only-rootfs'        "
 			]
 		},
@@ -69,9 +66,6 @@
 			"local.conf": [
 				"MACHINE                    = 'raspberrypi4'           ",
 				"ENABLE_UART                = '1'                      ",
-				"INHERIT                   += 'extrausers'             ",
-				"EXTRA_USERS_PARAMS_append  = 'usermod -P ROOT  root;' ",
-				"EXTRA_USERS_PARAMS_append  = 'useradd -P PI    pi;'   ",
 				"EXTRA_IMAGE_FEATURES      += 'read-only-rootfs'       "
 			]
 		}

--- a/sample-menus/riscv-menu-extrauser.json
+++ b/sample-menus/riscv-menu-extrauser.json
@@ -18,6 +18,11 @@
 	],
 
 	"local.conf" : [
+		"INHERIT += 'extrausers'     ",
+		"# `risc` password: `v` ",
+		"EXTRA_USERS_PARAMS_append  = \"useradd -p \\$5\\$FZf5SWAWvASrbUWA\\$s.RUVnPXk5WE.ousaVAWSGI/wCnlsyHyrWmgxoEHUu4  risc;\"     ",
+		"# `root` password: `linux` ",
+		"EXTRA_USERS_PARAMS_append  = \"usermod -p \\$5\\$oWODdN2qVYVBB5Nl\\$NrH9rY/8gxTkbdEbNzBK9Iu5KLlSppkOhooF8sP2mo/  root;\"     "
 	],
 
 	"builds" : {


### PR DESCRIPTION
Fix an error in the `usermod` command. For some reason it did not fail while the `-P` option did not exist. On recent shadow version, `-P` is for `--prefix` and the build fails.