### PR TITLE
[FIX] Bad path in variable TEMPLATE_CONF in class PokyDistro 

### DIFF
--- a/test/basic/dry-run/output.ref
+++ b/test/basic/dry-run/output.ref
@@ -71,7 +71,7 @@ cat > /builds/build-pi2-base/conf/bblayers.conf <<-EOF
 
 EOF
 cat > /builds/build-pi2-base/conf/templateconf.cfg <<-EOF
-	meta-poky/conf
+	None
 
 EOF
 # Building pi2-base (core-image-base)

--- a/test/basic/generate/test
+++ b/test/basic/generate/test
@@ -81,3 +81,41 @@ dirsExist . builds 1
 dirsExist builds build-first-inherited 1
 # .template must not be generated
 dirsExist builds build-.template 0
+
+##################################
+# Test versions < langdale (4.1) #
+##################################
+# Erase layers directory if exists
+rm -rf layers
+# Delete cooker configuration
+rm -f .cookerconfig
+# Simulate poky local.conf.sample file for versions < langdale
+mkdir -p layers/poky/meta-poky/conf
+touch layers/poky/meta-poky/conf/local.conf.sample
+
+cooker init -f $S/menu.json
+cooker generate
+
+# Test that inside templateconf.cfg the path should be "meta-poky/conf"
+# and not "None" when poky version is < langdale
+textInFile builds/build-first/conf/templateconf.cfg 'None' 0
+textInFile builds/build-first/conf/templateconf.cfg 'meta-poky/conf' 1
+
+###################################
+# Test versions >= langdale (4.1) #
+###################################
+# Erase layers directory if exists
+rm -rf layers
+# Delete cooker configuration
+rm -f .cookerconfig
+# Simulate poky local.conf.sample file for versions >= langdale
+mkdir -p layers/poky/meta-poky/conf/templates/default
+touch layers/poky/meta-poky/conf/templates/default/local.conf.sample
+
+cooker init -f $S/menu.json
+cooker generate
+
+# Test that inside templateconf.cfg the path should be "meta-poky/conf/templates/default"
+# and not "None" when poky version is >= langdale
+textInFile builds/build-first/conf/templateconf.cfg 'None' 0
+textInFile builds/build-first/conf/templateconf.cfg 'meta-poky/conf/templates/default' 1


### PR DESCRIPTION
The new versions of poky uses `meta-poky/conf/templates/default` instead of `meta-poky/conf` as the path for the template file (Changed in commit [c472d9ba9e970ad4c9bacf7851fcf6245fd03c40](https://git.yoctoproject.org/poky/commit/meta-poky/conf/templates/default/local.conf.sample?id=c472d9ba9e970ad4c9bacf7851fcf6245fd03c40))

This is causing an error and preventing to use yocto-cooker with the new versions of poky.

Issue to resolve: #134 