### PR TITLE
Add overridden distro configuration for poky

### DIFF
--- a/cooker/cooker-menu-schema.json
+++ b/cooker/cooker-menu-schema.json
@@ -141,6 +141,25 @@
 
         "notes": {
             "$ref": "#/definitions/notes"
+        },
+
+        "override_distro": {
+            "type": "object",
+            "properties": {
+                "base_directory": {
+                    "type": "string",
+                    "minLength": 1
+                },
+                "build_script": {
+                    "type": "string",
+                    "minLength": 1
+                },
+                "template_conf": {
+                    "type": "string",
+                    "minLength": 1
+                }
+            },
+            "additionalProperties": false
         }
     },
     "required": ["sources", "builds"],

--- a/cooker/cooker.py
+++ b/cooker/cooker.py
@@ -387,6 +387,9 @@ class CookerCommands:
                 self.distro = distros[name.lower()]
             except:
                 fatal_error('base-distribution {} is unknown, please add a `base-distribution.py` file next your menu.'.format(name))
+            
+            # Update distro if custom distro is defined in menu
+            self.update_override_distro()
 
     def init(self, menu_name, layer_dir=None, build_dir=None, dl_dir=None, sstate_dir=None):
         """ cooker-command 'init': (re)set the configuration file """
@@ -766,6 +769,14 @@ class CookerCommands:
         if not CookerCall.os.replace_process(shell, [shell, '-c', ". {} {}; {}".format(init_script, build_dir, shell)]):
             fatal_error('could not run interactive shell for {} with {}', build_names[0], shell)
 
+    def update_override_distro(self):
+        """ update distro values from menu file if exists """
+        override_distro = self.menu.get("override_distro", {})
+        if override_distro:
+            self.distro.BASE_DIRECTORY = override_distro.get("base_directory", self.distro.BASE_DIRECTORY)
+            self.distro.BUILD_SCRIPT = override_distro.get("build_script", self.distro.BUILD_SCRIPT)
+            # Template conf must be a tuple
+            self.distro.TEMPLATE_CONF = (override_distro.get("template_conf", self.distro.TEMPLATE_CONF),)
 
 class CookerCall:
     """

--- a/test/basic/dry-run/override-menu.json
+++ b/test/basic/dry-run/override-menu.json
@@ -1,0 +1,21 @@
+{
+    "sources": [],
+    "layers": [
+        "generic/layer1",
+        "generic/layer2"
+    ],
+    "override_distro": {
+        "base_directory": "poky",
+        "build_script": "oe-init-build-env",
+        "template_conf": "../meta-yocto/meta-poky/conf/templates/default"
+    },
+    "builds": {
+        "override": {
+            "target": "bitbake-target",
+            "layers": [
+                "override/layer1",
+                "override/layer2"
+            ]
+        }
+    }
+}

--- a/test/basic/dry-run/test
+++ b/test/basic/dry-run/test
@@ -27,6 +27,33 @@ sed -i "s|$(pwd)||g" output
 
 diff $S/output.ref output
 
+########################
+# Test override distro #
+########################
+# Erase layers directory if exists
+rm -rf layers
+
+# Simulate layers directory for override distro
+mkdir -p layers/poky/
+mkdir -p layers/meta-yocto/meta-poky/conf/templates/default
+touch layers/meta-yocto/meta-poky/conf/templates/default/local.conf.sample
+
+# Call cooker cook with a menu that contains an override distro
+cooker --dry-run cook $S/override-menu.json > output.txt
+
+# Remove personal path from output
+sed -i "s|$(pwd)||g" output.txt
+
+# Test if inside the output.txt has the correct path for build_script
+# build_script should be base_directory + "/" + build_script
+textInFile output.txt 'poky/oe-init-build-env' 1
+
+# Test if inside the output.txt has the correct path for template_conf
+textInFile output.txt '../meta-yocto/meta-poky/conf/templates/default' 1
+
+# Clean up
+rm -f output.txt
+
 exit 0
 
 

--- a/test/basic/init/override-menu-invalid-property.json
+++ b/test/basic/init/override-menu-invalid-property.json
@@ -1,0 +1,10 @@
+{
+    "sources": [],
+    "layers": [],
+    "override_distro": {
+        "base_directory": "poky",
+        "build_script": {},
+        "template_conf": "../meta-yocto/meta-poky/conf/templates/default"
+    },
+    "builds": {}
+}

--- a/test/basic/init/override-menu-unknown-property.json
+++ b/test/basic/init/override-menu-unknown-property.json
@@ -1,0 +1,11 @@
+{
+    "sources": [],
+    "layers": [],
+    "override_distro": {
+        "base_directory": "poky",
+        "build_script": "oe-init-build-env",
+        "template_conf": "../meta-yocto/meta-poky/conf/templates/default",
+        "unknown_property": "unknown-value"
+    },
+    "builds": {}
+}

--- a/test/basic/init/test
+++ b/test/basic/init/test
@@ -76,3 +76,13 @@ textInFile .cookerconfig '"layer-dir": "layers_dir",' 1
 textInFile .cookerconfig '"build-dir": "builds",' 1
 textInFile .cookerconfig '"dl-dir": "downloads"' 1
 textInFile .cookerconfig '"sstate-dir": "sstate_dir"' 1
+
+########################
+# Test override distro #
+########################
+
+# Test should fail when an invalid property is used in override_distro
+expect_fail cooker init -f $S/override-menu-invalid-property.json
+
+# Test should fail when an unkown property is used in override_distro
+expect_fail cooker init -f $S/override-menu-unknown-property.json


### PR DESCRIPTION
- Add function to get the overridden distro configuration if it exists
- Add rule in schema to allow to add a new entry in menu
- Add test case for an overridden distro

This is needed for a somewhat exotic setup : When you clone the individual Yocto repo instead of the poky.git combo-layer (Which is easier in order to contribute upstream). In this case the cloned repos can't have the same layout as poky.git.

Note: Ever is the author of the patches, I've reviewed them and will handle the PR from here (Ever has agreed. I hope that's OK)