### PR TITLE
Add support for executing a command in a poky-initialized shell (v2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,9 @@ files).
   with all the environment variables set. Some typical uses could be to
   run `bitbake -c menuconfig virtual/kernel` or `runqemu qemuarm` for instance.
   Simply `exit` the shell to return back to your previous working directory.
+  Alternatively, you can run `cooker shell <build-config> -- <command>` to run
+  the command in the environment.
+  For example : `cooker shell <build-config> -- runqemu nographics`.
 
 Each sub-command has additional command line options, e.g. with `init` the
 download-dir can be set using the `-d` switch.

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,0 +1,7 @@
+CMakeCache.txt
+CMakeFiles/
+cmake_install.cmake
+CTestTestfile.cmake
+Makefile
+Testing/
+tests/

--- a/test/basic/shell/output.ref
+++ b/test/basic/shell/output.ref
@@ -1,2 +1,4 @@
 exec /bin/sh /bin/sh -c . /layers/poky/oe-init-build-env /builds/build-pi2-base; /bin/sh
 exec /bin/sh /bin/sh -c . /layers/poky/oe-init-build-env /builds/build-qemu; /bin/sh
+/bin/sh -c source /layers/poky/oe-init-build-env /builds/build-qemu > /dev/null || exit 1; echo test
+/bin/sh -c source /layers/poky/oe-init-build-env /builds/build-qemu > /dev/null || exit 1; echo 'test with spaces and quotes "'

--- a/test/basic/shell/test
+++ b/test/basic/shell/test
@@ -6,9 +6,10 @@ cooker init $S/menu-01.json
 rm -f output.txt
 cooker --dry-run shell pi2-base >output.txt
 cooker --dry-run shell qemu >>output.txt
+cooker --dry-run shell qemu echo test >>output.txt
+cooker --dry-run shell qemu echo "test with spaces and quotes \"" >>output.txt
 
 sed -i "s|$(pwd)||g" output.txt
-
 diff $S/output.ref output.txt
 
 exit 0


### PR DESCRIPTION
PR initially from @amine-smile : https://github.com/cpb-/yocto-cooker/pull/145.

Updated the shell command to support executing a command within the poky-initialized shell. Introduced optional positional arguments, which allows users to specify a command to be executed (similar to what ssh does).  When a command argument is provided, it is executed within the shell environment.

Example: `cooker shell <cooker-build>  'bitbake -c cve_check <package-name>'`

The unittest was added : Only check the generated command line with dry-run. Actually testing that the command run correctly would require cloning a poky environment.

And, also, a minor gitignore improvement.
