### PR TITLE
Support for custom distro

### DIFF
--- a/cooker/cooker.py
+++ b/cooker/cooker.py
@@ -7,6 +7,7 @@ import json
 import os
 import re
 import sys
+import importlib.util
 from urllib.parse import urlparse
 import jsonschema
 import pkg_resources
@@ -482,19 +483,8 @@ class CookerCommands:
     def __init__(self, config, menu):
         self.config = config
         self.menu = menu
-        if menu is not None:
-            distros = {
-                'poky': PokyDistro,
-                'arago': AragoDistro,
-            }
-            name = menu.setdefault('base-distribution', 'poky')
-            try:
-                self.distro = distros[name.lower()]
-            except:
-                fatal_error('base-distribution {} is unknown, please add a `base-distribution.py` file next your menu.'.format(name))
 
-            # Update distro if custom distro is defined in menu
-            self.update_override_distro()
+        self.load_distro()
 
     def init(self, menu_name, layer_dir=None, build_dir=None, dl_dir=None, sstate_dir=None):
         """ cooker-command 'init': (re)set the configuration file """
@@ -513,6 +503,7 @@ class CookerCommands:
             self.config.set_sstate_dir(sstate_dir)
 
         self.config.save()
+        self.load_distro()
 
     def update(self):
         info('Update layers in project directory')
@@ -1052,6 +1043,38 @@ class CookerCommands:
             self.distro.BUILD_SCRIPT = override_distro.get("build_script", self.distro.BUILD_SCRIPT)
             # Template conf must be a tuple
             self.distro.TEMPLATE_CONF = (override_distro.get("template_conf", self.distro.TEMPLATE_CONF),)
+
+    def load_distro(self):
+        # Load the custom distro only after cooker config file is generated
+        # from init command (needs the menu location to find the distro file)
+
+        if not self.config.empty():
+            distros = {
+                'poky': PokyDistro,
+                'arago': AragoDistro,
+            }
+            name = self.menu.setdefault('base-distribution', 'poky').lower()
+
+            if name not in distros:
+                distro_dir = os.path.dirname(self.config.menu())
+                distro_file = os.path.join(distro_dir, '{}.py'.format(name))
+                distro_class_name = '{}Distro'.format(name.capitalize())
+                if CookerCall.os.file_exists(distro_file):
+                    distro_spec = importlib.util.spec_from_file_location("distro", distro_file)
+                    distro_module = importlib.util.module_from_spec(distro_spec)
+                    distro_spec.loader.exec_module(distro_module)
+                    try:
+                        distro_class = getattr(distro_module, distro_class_name)
+                    except AttributeError as e:
+                        fatal_error('distribution file `{}.py` does not contain a {} class'.format(name, distro_class_name))
+                    distros[name] = distro_class
+                else:
+                    fatal_error('base-distribution `{0}` is unknown, please add a `{0}.py` file next your menu.'.format(name))
+
+            self.distro = distros[name]
+
+            # Update distro if custom distro is defined in menu
+            self.update_override_distro()
 
 
 class CookerCall:


### PR DESCRIPTION
I have the same problem as Romain had in the [issue 97](https://github.com/cpb-/yocto-cooker/issues/97) , using a custom distro.

I read the discussion and the commit [ea103b6](https://github.com/cpb-/yocto-cooker/commit/ea103b616eb6aa22cd970ffc43b7879e78e9c138) that closed the issue. Importing a distro class from a python file next to the menu file, as you suggested, is the solution but not completely implemented. This PR implements this part.

But I'm not quite fan of creating a python file with a distro class while all other configurations are in the menu file. The override distro fields are more suited, but limited to `base_directory`, `build_script` and `template_conf`. Why not define all distro fields in `base_distribution` , with default values from the PokyDistro class ? 

Something like:
```json
"base-distribution": [
    "distro-name": "foo",
    "layer-conf-name": "LCONF_VERSION",
    "layer-conf-version": "6",
]
```
Will override the PokyDistro class value to create a custom distro class. Thus, for a complete custom distro all fields must be filled in as in the python file.

I leave this PR as a draft.