### PR TITLE
fix: replace tabs to four spaces in bblayers.conf

### DIFF
--- a/cooker/cooker.py
+++ b/cooker/cooker.py
@@ -894,7 +894,7 @@ class CookerCommands:
         CookerCall.os.file_write(file, 'BBLAYERS ?= " \\')
         for layer in sorted(build.layers()):
             layer_path = os.path.relpath(self.config.layer_dir(layer), build.dir())
-            CookerCall.os.file_write(file, "\t${{TOPDIR}}/{} \\".format(layer_path))
+            CookerCall.os.file_write(file, "    ${{TOPDIR}}/{} \\".format(layer_path))
         CookerCall.os.file_write(file, '"\n')
         CookerCall.os.file_close(file)
 

--- a/test/basic/dry-run/output.ref
+++ b/test/basic/dry-run/output.ref
@@ -65,11 +65,11 @@ cat > /builds/build-pi2-base/conf/bblayers.conf <<-EOF
 	BBPATH = "\${TOPDIR}"
 	BBFILES ?= ""
 	BBLAYERS ?= " \
-		\${TOPDIR}/../../layers/meta-openembedded/meta-oe \
-		\${TOPDIR}/../../layers/meta-raspberrypi \
-		\${TOPDIR}/../../layers/poky/meta \
-		\${TOPDIR}/../../layers/poky/meta-poky \
-		\${TOPDIR}/../../layers/poky/meta-yocto-bsp \
+	    \${TOPDIR}/../../layers/meta-openembedded/meta-oe \
+	    \${TOPDIR}/../../layers/meta-raspberrypi \
+	    \${TOPDIR}/../../layers/poky/meta \
+	    \${TOPDIR}/../../layers/poky/meta-poky \
+	    \${TOPDIR}/../../layers/poky/meta-yocto-bsp \
 	"
 
 EOF

--- a/test/basic/generate/one-target-first-bblayers.conf
+++ b/test/basic/generate/one-target-first-bblayers.conf
@@ -5,9 +5,9 @@ POKY_BBLAYERS_CONF_VERSION = "2"
 BBPATH = "${TOPDIR}"
 BBFILES ?= ""
 BBLAYERS ?= " \
-	${TOPDIR}/../../layers/first/layer1 \
-	${TOPDIR}/../../layers/first/layer2 \
-	${TOPDIR}/../../layers/generic/layer1 \
-	${TOPDIR}/../../layers/generic/layer2 \
+    ${TOPDIR}/../../layers/first/layer1 \
+    ${TOPDIR}/../../layers/first/layer2 \
+    ${TOPDIR}/../../layers/generic/layer1 \
+    ${TOPDIR}/../../layers/generic/layer2 \
 "
 


### PR DESCRIPTION
Tabulation in the BBLAYERS variable can lead to parsing error for some Yocto tools (such as the toast bbclass). Use spaces instead to maintain the readability of the generated bblayers.conf.

Fix #157 